### PR TITLE
keystonev3 allow to pass user_domain differing auth domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,19 @@ The URL and credentials details are necessary to authenticate with the identity 
 To provide a Keystone V3, which is the default recommended version:
 ```ruby
 auth = {
-  :url      => "http://localhost:5000",
-  :user     => "admin",
-  :password => "secret",
-  :project  => "admin",
-  :domain   => "default"
+  :url         => "http://localhost:5000",
+  :user        => "admin",
+  :user_domain => "default",
+  :password    => "secret",
+  :project     => "admin",
+  :domain      => "default"
   }
 }
 ```
+
+- `:user_domain` is optional, if you omit the parameter: it falls back to the value of `:domain`
+- `:domain` is optional, if you omit the parameter: it falls back to 'default'
+
 Alternatively, for Keystone V2, just provide the tenant details, Misty will detect it's using Keystone V2:
 ```ruby
 auth = {

--- a/docs/examples/auth_v3.rb
+++ b/docs/examples/auth_v3.rb
@@ -1,9 +1,10 @@
 def auth_v3
   {
-    :url      => "http://localhost:5000",
-    :user     => "admin",
-    :password => "secret",
-    :project  => "admin",
-    :domain   => "default"
+    :url         => "http://localhost:5000",
+    :user        => "admin",
+    :user_domain => "default",
+    :password    => "secret",
+    :project     => "admin",
+    :domain      => "default"
   }
 end

--- a/lib/misty/auth/auth_v3.rb
+++ b/lib/misty/auth/auth_v3.rb
@@ -33,6 +33,7 @@ module Misty
 
     def scoped_credentials(creds)
       creds[:domain] ||= "default"
+      creds[:user_domain] ||= creds[:domain]
       {
         "auth": {
           "identity": {
@@ -40,7 +41,7 @@ module Misty
             "password": {
               "user": {
                 "name": creds[:user],
-                "domain": { "id": "default" },
+                "domain": { "id": creds[:user_domain] },
                 "password": creds[:password]
               }
             }


### PR DESCRIPTION
e.g. my user lives in the default domain, but I can still scope my token to my second 'custom' domain :)