### PR TITLE
use proxy env if available

### DIFF
--- a/lib/misty/http/net_http.rb
+++ b/lib/misty/http/net_http.rb
@@ -2,10 +2,11 @@ module Misty
   module HTTP
     module NetHTTP
       def net_http(uri, ssl_verify_mode, log)
-        http = Net::HTTP.new(uri.host, uri.port)
         if ENV['http_proxy']
           proxy_uri = URI.parse(ENV['http_proxy']) 
           http = Net::HTTP.new(uri.host, uri.port, proxy_uri.host, proxy_uri.port)
+        else
+          http = Net::HTTP.new(uri.host, uri.port)
         end
         http.set_debug_output(log) if log.level == Logger::DEBUG
         if uri.scheme == "https"

--- a/lib/misty/http/net_http.rb
+++ b/lib/misty/http/net_http.rb
@@ -3,6 +3,10 @@ module Misty
     module NetHTTP
       def net_http(uri, ssl_verify_mode, log)
         http = Net::HTTP.new(uri.host, uri.port)
+        if ENV['http_proxy']
+          proxy_uri = URI.parse(ENV['http_proxy']) 
+          http = Net::HTTP.new(uri.host, uri.port, proxy_uri.host, proxy_uri.port)
+        end
         http.set_debug_output(log) if log.level == Logger::DEBUG
         if uri.scheme == "https"
           http.use_ssl = true

--- a/lib/misty/http/net_http.rb
+++ b/lib/misty/http/net_http.rb
@@ -2,11 +2,10 @@ module Misty
   module HTTP
     module NetHTTP
       def net_http(uri, ssl_verify_mode, log)
+        http = Net::HTTP.new(uri.host, uri.port)
         if ENV['http_proxy']
           proxy_uri = URI.parse(ENV['http_proxy']) 
           http = Net::HTTP.new(uri.host, uri.port, proxy_uri.host, proxy_uri.port)
-        else
-          http = Net::HTTP.new(uri.host, uri.port)
         end
         http.set_debug_output(log) if log.level == Logger::DEBUG
         if uri.scheme == "https"


### PR DESCRIPTION
for some reason Net::HTTP did not recognizes the http_proxy ENV variable, so I added an if case to use http_proxy if available 