### PR TITLE
decrease minimum required version for json gem to 1.8.3

### DIFF
--- a/misty.gemspec
+++ b/misty.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ['--charset=UTF-8']
   spec.extra_rdoc_files = %w[README.md LICENSE.md]
 
-  spec.add_dependency 'json', '~> 2.0'
+  spec.add_dependency 'json', '>= 1.8.3', '< 3'
 
   spec.add_development_dependency 'bundler',    '~> 1.10'
   spec.add_development_dependency 'rake',       '~> 10.0'


### PR DESCRIPTION
ActiveSupport for Rails 4 requires `json ~> 1.7 >= 1.7.7` which is
incompatible with Misty's previous requirement of `json ~> 2.0`. To be
able to use Misty with an existing Rails 4 application, we verified that
the unit tests pass with version 1.8.3 of the json gem (which is the
last version before 2.0).

According to the [release notes for the json gem][1], the only
backwards-incompatible change in 2.0 was to drop support for older
Rubies, so this should not break anything in practice.

[1]: https://github.com/flori/json/blob/master/CHANGES.md