### PR TITLE
allow to authenticate with token instead of user/password

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ The following parameters can be used:
   User domain id
 * `:user_domain`  
   User domain name  
+* `:password`
+  Password for user. Cannot be used together with `:token`.
+* `:token`
+  Previous Keystone v3 token for user. Can only be used with Keystone v3. Overrides all user and password parameters.
 
 #### Keystone v3
 Keystone v3 is default recommended version:

--- a/lib/misty/auth/auth_v3.rb
+++ b/lib/misty/auth/auth_v3.rb
@@ -15,12 +15,20 @@ module Misty
     end
 
     def credentials
+      if @token
+        identity = {
+          "methods": ["token"],
+          "token": { "id": @token }
+        }
+      else
+        identity = {
+          "methods": ["password"],
+          "password": @user.identity
+        }
+      end
       {
         "auth": {
-          "identity": {
-            "methods": ["password"],
-            "password":  @user.identity
-          },
+          "identity": identity,
           "scope": scope
         }
       }
@@ -58,10 +66,15 @@ module Misty
         @domain = Misty::Auth::DomainScope.new(domain_id, auth[:domain]) if domain_id || auth[:domain]
       end
 
-      user_domain_id = auth[:user_domain_id] ? auth[:user_domain_id] : Misty::DOMAIN_ID
-      @user = Misty::Auth::User.new(auth[:user_id], auth[:user])
-      @user.password = auth[:password]
-      @user.domain = Misty::Auth::Name.new(user_domain_id, auth[:user_domain])
+      if auth[:token]
+        @token = auth[:token]
+      else
+        user_domain_id = auth[:user_domain_id] ? auth[:user_domain_id] : Misty::DOMAIN_ID
+        @user = Misty::Auth::User.new(auth[:user_id], auth[:user])
+        @user.password = auth[:password]
+        @user.domain = Misty::Auth::Name.new(user_domain_id, auth[:user_domain])
+      end
+
       credentials
     end
   end

--- a/test/unit/auth_test.rb
+++ b/test/unit/auth_test.rb
@@ -12,7 +12,7 @@ describe Misty::Auth do
 
   describe Misty::AuthV3 do
     describe "#new" do
-      it "authenticates using project scoped authorization" do
+      it "authenticates with password using project scoped authorization" do
         auth = {
           :url        => "http://localhost:5000",
           :user_id    => "user_id",
@@ -28,7 +28,7 @@ describe Misty::Auth do
         Misty::AuthV3.new(auth, config)
       end
 
-      it "authenticates using domain scoped authorization" do
+      it "authenticates with password using domain scoped authorization" do
         auth = {
           :url      => "http://localhost:5000",
           :user_id  => "user_id",
@@ -37,6 +37,35 @@ describe Misty::Auth do
 
         stub_request(:post, "http://localhost:5000/v3/auth/tokens").
           with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"id\":\"user_id\",\"password\":\"secret\"}}},\"scope\":{\"domain\":{\"id\":\"default\"}}}}",
+            :headers => {'Accept'=>'application/json', 'Content-Type'=>'application/json'}).
+          to_return(:status => 200, :body => JSON.dump(auth_response_v3("identity", "keystone")), :headers => {"x-subject-token"=>"token_data"})
+
+        Misty::AuthV3.new(auth, config)
+      end
+
+      it "authenticates with token using project scoped authorization" do
+        auth = {
+          :url        => "http://localhost:5000",
+          :token      => "exampletoken",
+          :project_id => "project_id"
+        }
+
+        stub_request(:post, "http://localhost:5000/v3/auth/tokens").
+          with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"token\"],\"token\":{\"id\":\"exampletoken\"}},\"scope\":{\"project\":{\"id\":\"project_id\"}}}}",
+            :headers => {'Accept'=>'application/json', 'Content-Type'=>'application/json'}).
+          to_return(:status => 200, :body => JSON.dump(auth_response_v3("identity", "keystone")), :headers => {"x-subject-token"=>"token_data"})
+
+        Misty::AuthV3.new(auth, config)
+      end
+
+      it "authenticates with token using domain scoped authorization" do
+        auth = {
+          :url      => "http://localhost:5000",
+          :token    => "exampletoken",
+        }
+
+        stub_request(:post, "http://localhost:5000/v3/auth/tokens").
+          with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"token\"],\"token\":{\"id\":\"exampletoken\"}},\"scope\":{\"domain\":{\"id\":\"default\"}}}}",
             :headers => {'Accept'=>'application/json', 'Content-Type'=>'application/json'}).
           to_return(:status => 200, :body => JSON.dump(auth_response_v3("identity", "keystone")), :headers => {"x-subject-token"=>"token_data"})
 


### PR DESCRIPTION
Closes #22.

The unit tests are mostly copy-pasted from the password-based auth tests.

For your reference, the API documentation on how tokens can be used instead of username/password: https://developer.openstack.org/api-ref/identity/v3/index.html?expanded=token-authentication-with-scoped-authorization-detail#token-authentication-with-scoped-authorization