### PR TITLE
extend optional query argument to accept hashes and empty strings

### DIFF
--- a/lib/misty/http/method_builder.rb
+++ b/lib/misty/http/method_builder.rb
@@ -86,10 +86,16 @@ module Misty
 
       def query_param(data)
         if data.is_a? String
+          return '' if data == ''
           str = '?'
           str.force_encoding('ASCII-8BIT')
-          str << data unless data.empty?
+          str << data
+          return str
+        elsif data.is_a? Hash
+          return '' if data.empty?
+          return '?' + URI.encode_www_form(data)
         end
+        return nil
       end
     end
   end

--- a/lib/misty/http/method_builder.rb
+++ b/lib/misty/http/method_builder.rb
@@ -85,17 +85,18 @@ module Misty
       end
 
       def query_param(data)
+        result = nil
         if data.is_a? String
-          return '' if data == ''
-          str = '?'
-          str.force_encoding('ASCII-8BIT')
-          str << data
-          return str
+          result = ''
+          if data != ''
+            result = '?'
+            result.force_encoding('ASCII-8BIT')
+            result << data
+          end
         elsif data.is_a? Hash
-          return '' if data.empty?
-          return '?' + URI.encode_www_form(data)
+          result = data.empty? ? '' : '?' + URI.encode_www_form(data)
         end
-        return nil
+        return result
       end
     end
   end

--- a/test/unit/http/method_builder_test.rb
+++ b/test/unit/http/method_builder_test.rb
@@ -122,12 +122,23 @@ describe Misty::HTTP::MethodBuilder do
       service.send(:query_param, "name=foobar").must_equal "?name=foobar"
     end
 
-    it "returns nil when passing an empty String" do
-      service.send(:query_param, "").must_be_nil
+    it "returns empty string when passing an empty String" do
+      service.send(:query_param, "").must_equal ""
     end
 
-    it "returns nil unless passing a String" do
-      service.send(:query_param, "name" => "foobar").must_be_nil
+    it "returns a query string when passing in a Hash" do
+      service.send(:query_param, {}).must_equal ''
+
+      service.send(:query_param, {:foo  => 'bar'}).must_equal '?foo=bar'
+      service.send(:query_param, {'foo' => 'bar'}).must_equal '?foo=bar'
+
+      service.send(:query_param, {:foo => ['bar', 'baz'], :value => 42, :flag => nil }).must_equal '?foo=bar&foo=baz&value=42&flag'
+
+      service.send(:query_param, {'===' => 'Ëncøding is hárd!'}).must_equal '?%3D%3D%3D=%C3%8Bnc%C3%B8ding+is+h%C3%A1rd%21'
+    end
+
+    it "returns nil unless passing a String or Hash" do
+      service.send(:query_param, 42).must_be_nil
     end
   end
 end


### PR DESCRIPTION
1. The current handling of empty query strings is not useful.

       query_string = ""
       cloud.compute.list_servers(query_string) # FAIL

   This situation can arise quite easily when `query` is computed. See
   for example this mess:

   https://github.com/sapcc/elektra/blob/abdf808dc96a7fce4f47f04ccbe7fcbc07bffd0b/plugins/resource_management/lib/resource_management/driver/misty.rb#L19-L29

   This change makes query_param() return an empty string when given an
   empty query string, so that passing an empty query is a no-op as
   expected.

2. query_param() now optionally accepts a Hash instead of a query
   String, making possible more intuitive usage:

       cloud.compute.list_servers('name=first&name=second')  # before
       cloud.compute.list_servers(name: ['first', 'second']) # new