### PR TITLE
throw out all custom proxy handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,10 +216,6 @@ The following options are applied to each service unless specifically provided f
   Type: String  
   Allowed values: "public", "internal", "admin"  
   Default: "public"  
-* :http_proxy  
-  For example: `"http://userid:password@somewhere.com:8080/"` or `ENV["http_proxy"]`  
-  Type: String  
-  Default: `""`  
 * :ssl_verify_mode  
   When using SSL mode (defined by URI scheme => "https://")  
   Type: Boolean  

--- a/lib/misty/auth.rb
+++ b/lib/misty/auth.rb
@@ -27,7 +27,7 @@ module Misty
     def initialize(auth, config)
       raise URLError, "No URL provided" unless auth[:url] && !auth[:url].empty?
       @credentials = set_credentials(auth)
-      @http = net_http(URI.parse(auth[:url]), config.proxy, config.ssl_verify_mode, config.log)
+      @http = net_http(URI.parse(auth[:url]), config.ssl_verify_mode, config.log)
       @token = nil
       @token, @catalog, @expires = set(authenticate)
       raise CatalogError, "No catalog provided during authentication" if @catalog.empty?

--- a/lib/misty/cloud.rb
+++ b/lib/misty/cloud.rb
@@ -4,7 +4,7 @@ require 'misty/auth/auth_v3'
 module Misty
   class Cloud
     class Config
-      attr_accessor :auth, :content_type, :interface, :log, :proxy, :region_id, :ssl_verify_mode
+      attr_accessor :auth, :content_type, :interface, :log, :region_id, :ssl_verify_mode
     end
 
     def self.dot_to_underscore(val)
@@ -26,8 +26,6 @@ module Misty
       config.log.level = params[:log_level] ? params[:log_level] : Misty::LOG_LEVEL
       config.region_id = params[:region_id] ? params[:region_id] : Misty::REGION_ID
       config.ssl_verify_mode = params.key?(:ssl_verify_mode) ? params[:ssl_verify_mode] : Misty::SSL_VERIFY_MODE
-      http_proxy = params[:http_proxy] ? params[:http_proxy] : ""
-      config.proxy = URI.parse(http_proxy)
       config
     end
 

--- a/lib/misty/http/client.rb
+++ b/lib/misty/http/client.rb
@@ -54,7 +54,7 @@ module Misty
         @uri = URI.parse(@auth.get_endpoint(@options.service_names, @options.region_id, @options.interface))
         @base_path = @options.base_path ? @options.base_path : @uri.path
         @base_path = @base_path.chomp("/")
-        @http = net_http(@uri, @config.proxy, @options.ssl_verify_mode, @config.log)
+        @http = net_http(@uri, @options.ssl_verify_mode, @config.log)
         @version = nil
         @microversion = false
       end

--- a/lib/misty/http/net_http.rb
+++ b/lib/misty/http/net_http.rb
@@ -1,8 +1,8 @@
 module Misty
   module HTTP
     module NetHTTP
-      def net_http(endpoint, proxy, ssl_verify_mode, log)
-        http = Net::HTTP.new(endpoint.host, endpoint.port, proxy.host, proxy.port, proxy.user, proxy.password)
+      def net_http(endpoint, ssl_verify_mode, log)
+        http = Net::HTTP.new(endpoint.host, endpoint.port)
         http.set_debug_output(log) if log.level == Logger::DEBUG
         if endpoint.scheme == "https"
           http.use_ssl = true

--- a/test/unit/auth_test.rb
+++ b/test/unit/auth_test.rb
@@ -5,7 +5,6 @@ describe Misty::Auth do
   let(:config) do
     config = Misty::Cloud::Config.new
     config.log = Logger.new('/dev/null')
-    config.proxy = URI.parse("")
     config.ssl_verify_mode = false
     config
   end

--- a/test/unit/cloud_test.rb
+++ b/test/unit/cloud_test.rb
@@ -58,8 +58,6 @@ describe Misty::Cloud do
         config.content_type.must_equal Misty::CONTENT_TYPE
         config.log.must_be_kind_of Logger
         config.interface.must_equal Misty::INTERFACE
-        config.proxy.must_be_kind_of URI
-        config.proxy.host.must_be_nil
         config.region_id.must_equal Misty::REGION_ID
         config.ssl_verify_mode.must_equal Misty::SSL_VERIFY_MODE
       end

--- a/test/unit/http/client_test.rb
+++ b/test/unit/http/client_test.rb
@@ -42,8 +42,7 @@ describe Misty::HTTP::Client do
   describe "#net_http" do
     it "returns a Net/http instance" do
       endpoint = URI.parse("http://localhost")
-      proxy = URI.parse("")
-      service.send(:net_http, endpoint, proxy, false, Logger.new("/dev/null")).must_be_instance_of Net::HTTP
+      service.send(:net_http, endpoint, false, Logger.new("/dev/null")).must_be_instance_of Net::HTTP
     end
   end
 

--- a/test/unit/openstack/microversion_test.rb
+++ b/test/unit/openstack/microversion_test.rb
@@ -35,7 +35,6 @@ describe Misty::HTTP::Microversion do
     setup.content_type = :ruby
     setup.log = Logger.new('/dev/null')
     setup.interface = Misty::INTERFACE
-    setup.proxy = URI.parse('')
     setup.region_id = Misty::REGION_ID
     setup.ssl_verify_mode = Misty::SSL_VERIFY_MODE
 

--- a/test/unit/service_helper.rb
+++ b/test/unit/service_helper.rb
@@ -19,7 +19,6 @@ def service(content_type = :ruby)
   setup.content_type = content_type
   setup.log = Logger.new('/dev/null')
   setup.interface = Misty::INTERFACE
-  setup.proxy = URI.parse("")
   setup.region_id = Misty::REGION_ID
   setup.ssl_verify_mode = Misty::SSL_VERIFY_MODE
 


### PR DESCRIPTION
It turns out that the problems that @hgw was seeing do not exist: proxy handling worked fine before the 0.5.1 changes. In fact, the 0.5.1 changes broke scenarios where the `NO_PROXY` variable is needed, which is currently blocking some of our colleagues in offices where there is still a corporate proxy.

I've tested the following scenarios and they all work flawlessly for me:

1. no proxy set -> direct connection to all endpoints
2. only HTTP(S)_PROXY set -> everything goes through the proxy
3. HTTP(S)_PROXY and also NO_PROXY set -> some connections are proxyless
   as indicated by the NO_PROXY variable