### PR TITLE
Specify the minimum supported Ruby version.

### DIFF
--- a/misty.gemspec
+++ b/misty.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/flystack/misty'
   spec.license       = 'Apache-2.0'
 
+  spec.required_ruby_version = '>= 2.3'
+
   all_files          = `git ls-files -z`.split("\x0")
   spec.files         = all_files.grep(%r{^(exe|lib|test)/|^.rubocop.yml$})
   spec.executables   = all_files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Without this, it's possible to install the gem on older versions of Ruby without warnings and then we see syntax errors.

https://gist.github.com/Skarzee/6f11657cf707a747d99302e5b2255cc6