### PR TITLE
Header refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ The following options are applied to each service unless specifically provided f
   Default: `:ruby`
 
 ### Services Options
-Each service can get parameters to be specified.
+Each service can have specific parameters.
 
 ```ruby
 openstack = Misty::Cloud.new(:auth => auth, :identity => {}, :compute => {})
@@ -279,7 +279,10 @@ The following options are available:
   Type: String  
 * :base_url  
   Allows to force the base URL for every requests.  
-  Type: String  
+  Type: String        
+* :headers
+  Optional headers
+  Type: Hash
 * :interface  
   Allows to provide an alternate interface. Allowed values are "public", "internal" or "admin"  
   Type: String  

--- a/lib/misty/auth.rb
+++ b/lib/misty/auth.rb
@@ -42,10 +42,9 @@ module Misty
         @uri, ssl_verify_mode: @config.ssl_verify_mode, log: @config.log
       ) do |connection|
         response = connection.post(self.class.path, @credentials.to_json,
-                                   Misty::HEADER_JSON)
+          { 'Content-Type' => 'application/json', 'Accept' => 'application/json' })
         unless response.code =~ /200|201/
-          raise AuthenticationError,
-                "Response code=#{response.code}, Msg=#{response.msg}"
+          raise AuthenticationError, "Response code=#{response.code}, Msg=#{response.msg}"
         end
         response
       end

--- a/lib/misty/http/client.rb
+++ b/lib/misty/http/client.rb
@@ -37,15 +37,17 @@ module Misty
       #    :base_path => nil
       #   URL can be forced (Helps when setup is broken)
       #    :base_url => nil
+      #   Optional headers
+      #    :headers => {}
       #   Endpoint type (admin, public or internal)
-      #     :interface => "public"
+      #    :interface => "public"
       #   Region ID
       #    :region_id => "regionOne"
       #   Service name
       #    The Service names are pre defined but more can be added using this option.
       #    :service_name
       #   SSL Verify Mode
-      #     :ssl_verify_mode => true
+      #    :ssl_verify_mode => true
       #   (micro)version: Can be numbered (3.1) or by state (CURRENT, LATEST or SUPPORTED)
       #     :version => "CURRENT"
       def initialize(auth, config, options)
@@ -70,15 +72,14 @@ module Misty
         ''
       end
 
-      def headers_default
-        Misty::HEADER_JSON
-      end
-
       def headers
-        h = headers_default.merge('X-Auth-Token' => @auth.get_token.to_s)
-        h.merge!(microversion_header) if microversion
-        h.merge!(@options.headers) if @options.headers
-        h
+        header = {}
+        header.merge!({'Content-Type' => 'application/json', 'Accept' => 'application/json'})
+        header.merge!('X-Auth-Token' => @auth.get_token.to_s)
+        header.merge!(@config.headers) if @config.headers
+        header.merge!(@options.headers) if @options.headers
+        header.merge!(microversion_header) if microversion
+        header
       end
 
       private
@@ -95,7 +96,7 @@ module Misty
         options.region_id           = params[:region_id]       ? params[:region_id] : @config.region_id
         options.service_names       = params[:service_name]    ? self.class.service_names << params[:service_name] : self.class.service_names
         options.ssl_verify_mode     = params[:ssl_verify_mode] ? params[:ssl_verify_mode] : @config.ssl_verify_mode
-        options.headers             = params[:headers] ? params[:headers] : @config.headers
+        options.headers             = params[:headers]         ? params[:headers] : {}
         options.version             = params[:version]         ? params[:version] : 'CURRENT'
 
         unless INTERFACES.include?(options.interface)

--- a/lib/misty/microversion.rb
+++ b/lib/misty/microversion.rb
@@ -52,7 +52,7 @@ module Misty
     end
 
     def versions_fetch
-      response = http_get('/', headers_default)
+      response = http_get('/', {'Accept'=> 'application/json'})
       raise VersionError, "Code: #{response.code}, Message: #{response.msg}" unless response.code =~ /2??/
       data = response.body.is_a?(Hash) ? response.body : JSON.parse(response.body)
       list = data['versions']

--- a/lib/misty/misty.rb
+++ b/lib/misty/misty.rb
@@ -27,11 +27,6 @@ module Misty
     { name: :shared_file_systems,                 project: :manila,      microversion: 'v2'}
   ]
 
-  HEADER_JSON = {
-    'Content-Type' => 'application/json',
-    'Accept'       => 'application/json'
-  }
-
   # Default REST content type. Use :json or :ruby
   CONTENT_TYPE = :ruby
 

--- a/test/unit/cloud/services_test.rb
+++ b/test/unit/cloud/services_test.rb
@@ -33,7 +33,6 @@ describe 'Misty::Cloud' do
   let(:auth_headers) do
     { 'Accept' => 'application/json',
       'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-      'Content-Type'    => 'application/json',
       'User-Agent'      => 'Ruby' }
   end
 

--- a/test/unit/http/client_test.rb
+++ b/test/unit/http/client_test.rb
@@ -21,12 +21,6 @@ describe Misty::HTTP::Client do
     end
   end
 
-  describe '#headers_default' do
-    it 'returns hash' do
-      service.headers_default.must_be_kind_of Hash
-    end
-  end
-
   describe '#headers' do
     it 'returns hash' do
       service.headers.must_be_kind_of Hash

--- a/test/unit/microversion_test.rb
+++ b/test/unit/microversion_test.rb
@@ -39,7 +39,7 @@ describe Misty::Microversion do
     setup.ssl_verify_mode = Misty::SSL_VERIFY_MODE
 
     stub_request(:get, 'http://localhost/').
-      with(:headers => {'Accept'=>'application/json', 'Content-Type'=>'application/json'}).
+      with(:headers => {'Accept'=>'application/json'}).
       to_return(:status => 200, :body => JSON.dump(versions_data), :headers => {})
 
     Misty::Openstack::Nova::V2_1.new(auth, setup, {})

--- a/test/unit/service_helper.rb
+++ b/test/unit/service_helper.rb
@@ -1,7 +1,7 @@
 require 'misty/http/client'
 
 def request_header
-  {'Accept'=>'application/json', 'Content-Type'=>'application/json'}
+  {'Accept' => 'application/json'}
 end
 
 def service(content_type = :ruby)


### PR DESCRIPTION
Adds proper documentation for service headers option.
Refactors header handling: 
* Removed ```Misty::HEADER_JSON``` which is confusing besides being DRY  
* Removed Content-Type header for some GET requests.