### PR TITLE
Transparent HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # Introduction
-Misty is a HTTP client for OpenStack APIs, aiming to be fast and to provide a flexible and at same time exhaustive
-APIs experience.
+Misty is a HTTP client for OpenStack APIs, aiming to be fast, flexible and exhaustive.
+Misty acts as a conduit to OpenStack APIs by handling requests as transparently as possible.
 
 ## Features
 * Flexible Openstack APIs integration
 * Standardized Openstack APIs: [Based upon API-ref](https://developer.openstack.org/api-guide/quick-start/)
-* Multiple Service versions and Microversions
+* Automatically generated API schemas - Any request can be overridden
+* Versions and Microversions
+* Transparent Request data hanlding
+* Response data format of choice: JSON or raw (Ruby)
+* Custom HTTP Methods for special needs
 * On demand services - Auto loads required versions
-* Low  dependency - Use standard Net/HTTP and JSON gem only
-* I/O format choice: JSON or Ruby structures for queries and responses
-* Persistent HTTP connections (default since HTTP 1.1 anyway) but for the authentication bootstrapping
-* Direct HTTP Methods for custom needs
+* Low dependency - Use standard Net/HTTP and JSON gem only
+* Persistent HTTP connections (default since HTTP 1.1 anyway)
 
 ## A solid KISS
 For REST transactions Misty relies on standard Net/HTTP library.  
@@ -76,7 +78,8 @@ Each service name (i.e. `compute`) is the object handling API requests.
 openstack = Misty::Cloud.new(:auth => { ... })
 openstack.compute.list_servers
 openstack.network.list_networks
-openstack.network.create_network('network': {'name': 'my-network'})
+data = Misty.to_json('network': {'name': 'my-network'})
+openstack.network.create_network(data)
 ```
 
 To obtain the list of supported services:

--- a/docs/examples/cloud.rb
+++ b/docs/examples/cloud.rb
@@ -20,4 +20,5 @@ first_network_id = nets.body['networks'][0]['id']
 first_network = cloud.network.show_network_details(first_network_id)
 pp first_network
 
-pp cloud.network.create_network(:network => {:name => 'misty-example'})
+network = Misty.to_json(:network => {:name => 'misty-example'})
+pp cloud.network.create_network(network)

--- a/docs/examples/microversion.rb
+++ b/docs/examples/microversion.rb
@@ -7,7 +7,8 @@ cloud = Misty::Cloud.new(:auth => authv3, :compute => {:version => '2.25'})
 
 pp cloud.compute.versions
 
-admin_keypair = cloud.compute.create_or_import_keypair('keypair': {'name': 'admin-keypair'})
+data_keypair = Misty.to_json('keypair': {'name': 'admin-keypair'})
+admin_keypair = cloud.compute.create_or_import_keypair(data_keypair)
 
 user_id = admin_keypair.body['keypair']['user_id']
 

--- a/docs/examples/orchestration.rb
+++ b/docs/examples/orchestration.rb
@@ -35,8 +35,8 @@ heat_template = {
 }
 
 cloud = Misty::Cloud.new(:auth => auth_v3)
-
-response = cloud.orchestration.create_stack(heat_template)
+data_heat_template = Misty.to_json(heat_template)
+response = cloud.orchestration.create_stack(data_heat_template)
 id = response.body['stack']['id']
 
 stack = cloud.orchestration.show_stack_details('test_stack', id)

--- a/lib/misty/http/client.rb
+++ b/lib/misty/http/client.rb
@@ -74,7 +74,7 @@ module Misty
 
       def headers
         header = {}
-        header.merge!({'Content-Type' => 'application/json', 'Accept' => 'application/json'})
+        header.merge!({'Accept' => 'application/json; q=1.0'})
         header.merge!('X-Auth-Token' => @auth.get_token.to_s)
         header.merge!(@config.headers) if @config.headers
         header.merge!(@options.headers) if @options.headers

--- a/lib/misty/http/request.rb
+++ b/lib/misty/http/request.rb
@@ -54,21 +54,21 @@ module Misty
       def http_patch(path, headers, data)
         @config.log.info(http_to_s(path, headers, data))
         request = Net::HTTP::Patch.new(path, headers)
-        request.body = Misty.to_json(data)
+        request.body = data
         http(request)
       end
 
       def http_post(path, headers, data)
         @config.log.info(http_to_s(path, headers, data))
         request = Net::HTTP::Post.new(path, headers)
-        request.body = Misty.to_json(data)
+        request.body = data
         http(request)
       end
 
       def http_put(path, headers, data)
         @config.log.info(http_to_s(path, headers, data))
         request = Net::HTTP::Put.new(path, headers)
-        request.body = Misty.to_json(data)
+        request.body = data
         http(request)
       end
 

--- a/test/integration/compute_test.rb
+++ b/test/integration/compute_test.rb
@@ -7,7 +7,8 @@ describe 'Compute Service Nova v2.1 features' do
 
       # POST with body data
       server = { 'name': 'test_create_server', 'flavorRef': '1', 'imageRef': 'c091ccf2-a4ae-4fa0-a716-defd6376b5dc', 'networks': [{'uuid': '9c6e43b6-3d1d-4106-ad45-5fc3f5e371ee'}]}
-      response = cloud.compute.create_server('server' => server)
+      data = Misty.to_json('server' => server)
+      response = cloud.compute.create_server(data)
       response.code.must_equal '202'
       id = response.body['server']['id']
       id.wont_be_empty
@@ -24,7 +25,8 @@ describe 'Compute Service Nova v2.1 features' do
 
       # PUT with URI value and body data
       update_server = { 'name': 'test_updated_server' }
-      response = cloud.compute.update_server(id, 'server' => update_server)
+      data = Misty.to_json('server' => update_server)
+      response = cloud.compute.update_server(id, data)
       response.code.must_equal '200'
       response.body['server']['name'].must_equal 'test_updated_server'
 

--- a/test/integration/network_test.rb
+++ b/test/integration/network_test.rb
@@ -6,7 +6,8 @@ describe 'Network Service Neutron v2.0 features' do
       cloud = Misty::Cloud.new(:auth => auth, :network => {:api_version => 'v2.0'})
 
       # POST with body data
-      response = cloud.network.create_network('network' => { 'name': 'test_network' })
+      data = Misty.to_json('network' => { 'name': 'test_network' })
+      response = cloud.network.create_network(data)
       response.code.must_equal '201'
       id = response.body['network']['id']
       id.wont_be_empty
@@ -22,8 +23,8 @@ describe 'Network Service Neutron v2.0 features' do
       response.body['network']['name'].must_equal 'test_network'
 
       # PUT with URI value and body data
-      update_network = { 'name': 'test_updated_network' }
-      response = cloud.network.update_network(id, 'network' => update_network)
+      data = Misty.to_json('network' => { 'name': 'test_updated_network' })
+      response = cloud.network.update_network(id, data)
       response.code.must_equal '200'
       response.body['network']['name'].must_equal 'test_updated_network'
 

--- a/test/integration/orchestration_test.rb
+++ b/test/integration/orchestration_test.rb
@@ -53,12 +53,14 @@ describe 'Orchestration Service using Heat v1' do
       cloud = Misty::Cloud.new(:auth => auth, :orchestration => {:api_version => 'v1'})
 
       # POST with body data
-      response = cloud.orchestration.create_stack(heat_template1)
+      data_heat_template1 = Misty.to_json(heat_template1)
+      response = cloud.orchestration.create_stack(data_heat_template1)
       response.code.must_equal '201'
       id1 = response.body['stack']['id']
       id1.wont_be_empty
 
-      response = cloud.orchestration.create_stack(heat_template2)
+      data_heat_template2 = Misty.to_json(heat_template2)
+      response = cloud.orchestration.create_stack(data_heat_template2)
       response.code.must_equal '201'
       id2 = response.body['stack']['id']
       id2.wont_be_empty
@@ -77,11 +79,13 @@ describe 'Orchestration Service using Heat v1' do
       # Updating the network template because it's faster to execute
       # therefore more likely to be in ready state before updating
       heat_template1[:template][:description] = 'Updated test template'
-      response = cloud.orchestration.update_stack('test_stack1', id1, heat_template1)
+      data_heat_template1 = Misty.to_json(heat_template1)
+      response = cloud.orchestration.update_stack('test_stack1', id1, data_heat_template1)
       response.code.must_equal '202'
 
       # PATCH with URI values
-      response = cloud.orchestration.update_stack_patch('test_stack1', id1, 'disable_rollback': false)
+      data = Misty.to_json('disable_rollback': false)
+      response = cloud.orchestration.update_stack_patch('test_stack1', id1, data)
       response.code.must_equal '202'
 
       # DELETE with URI value

--- a/test/unit/http/direct_test.rb
+++ b/test/unit/http/direct_test.rb
@@ -61,19 +61,19 @@ describe Misty::HTTP::Direct do
   describe '#post' do
     it 'successful without providing a base url' do
       stub_request(:post, 'http://localhost/resource/test').
-        with(:body => "{\"data\":\"value\"}", :headers => request_header).
+        with(:body => 'data', :headers => request_header).
         to_return(:status => 201, :body => '', :headers => {})
 
-      response = service.post('/resource/test', 'data' => 'value')
+      response = service.post('/resource/test', 'data')
       response.must_be_kind_of Net::HTTPCreated
       response.body.must_be_nil
     end
 
     it 'successful with a base url' do
       stub_request(:post, 'http://localhost/another-base/resource/test').
-        with(:body => "{\"data\":\"value\"}", :headers => request_header).
+        with(:body => 'data', :headers => request_header).
         to_return(:status => 201, :body => '', :headers => {})
-      response = service.post('/resource/test', {'data' => 'value'}, '/another-base')
+      response = service.post('/resource/test', 'data', '/another-base')
       response.must_be_kind_of Net::HTTPCreated
       response.body.must_be_nil
     end
@@ -82,20 +82,20 @@ describe Misty::HTTP::Direct do
   describe '#put' do
     it 'successful without providing a base url' do
       stub_request(:put, 'http://localhost/resource/test').
-        with(:body => "{\"data\":\"value\"}", :headers => request_header).
+        with(:body => 'data', :headers => request_header).
         to_return(:status => 200, :body => '', :headers => {})
 
-      response = service.put('/resource/test', 'data' => 'value')
+      response = service.put('/resource/test', 'data')
       response.must_be_kind_of Net::HTTPOK
       response.body.must_be_nil
     end
 
     it 'successful with a base url' do
       stub_request(:put, 'http://localhost/another-base/resource/test').
-        with(:body => "{\"data\":\"value\"}", :headers => request_header).
+        with(:body => 'data', :headers => request_header).
         to_return(:status => 200, :body => '', :headers => {})
 
-      response = service.put('/resource/test', {'data' => 'value'}, '/another-base')
+      response = service.put('/resource/test', 'data', '/another-base')
       response.must_be_kind_of Net::HTTPOK
       response.body.must_be_nil
     end

--- a/test/unit/service_helper.rb
+++ b/test/unit/service_helper.rb
@@ -1,7 +1,7 @@
 require 'misty/http/client'
 
 def request_header
-  {'Accept' => 'application/json'}
+  {'Accept' => 'application/json; q=1.0'}
 end
 
 def service(content_type = :ruby)


### PR DESCRIPTION
Let's leave the server automatically handle the data format in PUT, POST and PATCH requests.