### PR TITLE
Headers injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ puts network.body
 ```
 
 ## Services
-Once the Misty::Cloud object is created, the Openstack services can be used.
+Once a Misty::Cloud object is created, the Openstack services can be used.
 
 The Cloud object is authenticated by the identity server (bootstrap) and is provided with a service catalog.
 When an OpenStack API service is required, the catalog entry's endpoint is used and the service is dynamically called.
@@ -110,6 +110,15 @@ orchestration: heat, versions: ["v1"]
 search: searchlight, versions: ["v1"]
 shared_file_systems: manila, microversion: v2
 ```
+
+### Headers
+HTTP headers can be defined at 3 different levels:
+* Global headers are applied across all services, see `:headers` in "Global parameters" section.
+* Service level headers are applied on every request of an involved service, see "Services options" section.
+* Request level header are passed on per request basis.
+
+The Headers are cumulative, therefore a request level header will be added on top of the global and Service levels
+headers.
 
 ### Prefixes
 A shorter name can be used to call a service only if it's unique among all services.
@@ -249,6 +258,15 @@ openstack = Misty::Cloud.new(:auth => auth, :content_type => :ruby, :log_file =>
 #### Global parameters
 The following options are applied to each service unless specifically provided for a service.
 
+* :content_type  
+  Format of the body of the successful HTTP responses to be JSON or Ruby structures.  
+  Type: Symbol  
+  Allowed values: `:json`, `:ruby`  
+  Default: `:ruby`
+* :headers  
+  HTTP Headers to be applied to all services
+  Type: Hash  
+  Default: {}
 * :region_id  
   Type: String  
   Default: "regionOne"  
@@ -260,11 +278,6 @@ The following options are applied to each service unless specifically provided f
   When using SSL mode (defined by URI scheme => "https://")  
   Type: Boolean  
   Default: `true`  
-* :content_type  
-  Format of the body of the successful HTTP responses to be JSON or Ruby structures.  
-  Type: Symbol  
-  Allowed values: `:json`, `:ruby`  
-  Default: `:ruby`
 
 ### Services Options
 Each service can have specific parameters.
@@ -309,6 +322,23 @@ The following options are available:
 Example:
 ```ruby
 openstack = Misty::Cloud.new(:auth => auth, :log_level => 0, :identity => {:region_id => 'regionTwo'}, :compute => {:version => '2.27', :interface => 'admin'})
+```
+
+### Services Headers
+HTTP headers can be optionally added to any request.
+A Header object must be created and passed as the last parameter of a request.
+
+For example for an already initialized cloud:
+```ruby
+header = Misty::HTTP::Header.new(
+  'x-container-meta-web-listings' => false,
+  'x-container-meta-quota-count'  => "",
+  'x-container-meta-quota-bytes'  => nil,
+  'x-versions-location'           => "",
+  'x-container-meta-web-index'    => ""
+)
+
+openstack.object_storage.create_update_or_delete_container_metadata(container_name, header)
 ```
 
 ## Direct REST HTTP Methods

--- a/lib/misty/cloud.rb
+++ b/lib/misty/cloud.rb
@@ -1,5 +1,6 @@
 require 'misty/auth/auth_v2'
 require 'misty/auth/auth_v3'
+require 'misty/http/header'
 
 module Misty
   class Cloud
@@ -13,7 +14,7 @@ module Misty
       val.gsub(/\./,'_')
     end
 
-    def initialize(params)# = {:auth => {}})
+    def initialize(params)
       @params = params
       @config = self.class.set_configuration(params)
       @auth = Misty::Auth.factory(params[:auth], @config)
@@ -27,7 +28,8 @@ module Misty
       config.log.level = params[:log_level] ? params[:log_level] : Misty::LOG_LEVEL
       config.region_id = params[:region_id] ? params[:region_id] : Misty::REGION_ID
       config.ssl_verify_mode = params.key?(:ssl_verify_mode) ? params[:ssl_verify_mode] : Misty::SSL_VERIFY_MODE
-      config.headers = params[:headers]
+      config.headers = Misty::HTTP::Header.new('Accept' => 'application/json; q=1.0')
+      config.headers.add(params[:headers]) if params[:headers] && !params[:headers].empty?
       config
     end
 

--- a/lib/misty/http/direct.rb
+++ b/lib/misty/http/direct.rb
@@ -7,19 +7,19 @@ module Misty
       end
 
       def delete(path, base_path = nil)
-        http_delete(base_set(base_path) + path, headers)
+        http_delete(base_set(base_path) + path, @headers.get)
       end
 
       def get(path, base_path = nil)
-        http_get(base_set(base_path) + path, headers)
+        http_get(base_set(base_path) + path, @headers.get)
       end
 
       def post(path, data, base_path = nil)
-        http_post(base_set(base_path) + path, headers, data)
+        http_post(base_set(base_path) + path, @headers.get, data)
       end
 
       def put(path, data, base_path = nil)
-        http_put(base_set(base_path) + path, headers, data)
+        http_put(base_set(base_path) + path, @headers.get, data)
       end
     end
   end

--- a/lib/misty/http/header.rb
+++ b/lib/misty/http/header.rb
@@ -1,0 +1,29 @@
+module Misty
+  module HTTP
+    class Header
+      class ArgumentError < RuntimeError; end
+      class TypeError     < RuntimeError; end
+
+      def self.valid?(param)
+        raise Misty::HTTP::Header::TypeError unless param.class == Hash
+        param.each do |key, val|
+          raise Misty::HTTP::Header::ArgumentError unless key.class == String
+          raise Misty::HTTP::Header::ArgumentError unless val.class == String
+        end
+        true
+      end
+
+      def initialize(param = {})
+        @headers = param if self.class.valid?(param)
+      end
+
+      def add(param = {})
+        @headers.merge!(param) if self.class.valid?(param)
+      end
+
+      def get
+        @headers
+      end
+    end
+  end
+end

--- a/lib/misty/http/method_builder.rb
+++ b/lib/misty/http/method_builder.rb
@@ -12,6 +12,9 @@ module Misty
       private
 
       def method_call(method, *args)
+        header = @headers.get.clone
+        header.merge!(args.pop.get) if args[-1].class == Misty::HTTP::Header
+
         base, path = prefixed_path(method[:path])
         size_path_parameters = count_path_params(path)
         path_params = args[0, size_path_parameters]
@@ -21,23 +24,23 @@ module Misty
 
         case method[:request]
         when :COPY
-          http_copy(final_path, headers)
+          http_copy(final_path, header)
         when :DELETE
-          http_delete(final_path, headers)
+          http_delete(final_path, header)
         when :GET
           final_path << query_param(args_left[0]) if args_left && args_left.size == 1
-          http_get(final_path, headers)
+          http_get(final_path, header)
         when :HEAD
-          http_head(final_path, headers)
+          http_head(final_path, header)
         when :POST
           data = args_left[0] if args_left && args_left.size == 1
-          http_post(final_path, headers, data)
+          http_post(final_path, header, data)
         when :PUT
           data = args_left[0] if args_left && args_left.size == 1
-          http_put(final_path, headers, data)
+          http_put(final_path, header, data)
         when :PATCH
           data = args_left[0] if args_left && args_left.size == 1
-          http_patch(final_path, headers, data)
+          http_patch(final_path, header, data)
         else
           raise SyntaxError, "Invalid HTTP request: #{method[:request]}"
         end

--- a/test/unit/cloud/requests_test.rb
+++ b/test/unit/cloud/requests_test.rb
@@ -46,6 +46,18 @@ describe Misty::Cloud do
       cloud.image.show_image_member_details('id1', 'id2').response.must_be_kind_of Net::HTTPOK
     end
 
+    it 'successful with an extra header parameter' do
+      stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+        to_return(:status => 200, :body => JSON.dump(auth_response_v3('network', 'neutron')), :headers => {'x-subject-token'=>'token_data'})
+
+      stub_request(:get, "http://localhost/v2.0/networks?name=value").
+        with(:headers => {'Test-Header'=>'test header value'}).
+        to_return(:status => 200, :body => "", :headers => {})
+
+      header = Misty::HTTP::Header.new('Test-Header' => 'test header value')
+      cloud.network.list_networks('name=value', header).response.must_be_kind_of Net::HTTPOK
+    end
+
     it 'fails when not enough arguments' do
       proc do
         # '/v2/images/{image_id}/members/{member_id}'

--- a/test/unit/cloud_test.rb
+++ b/test/unit/cloud_test.rb
@@ -56,9 +56,12 @@ describe Misty::Cloud do
       Misty::Auth.stub :factory, nil do
         config = Misty::Cloud.set_configuration({})
         config.must_be_kind_of Misty::Cloud::Config
+
         config.content_type.must_equal Misty::CONTENT_TYPE
-        config.log.must_be_kind_of Logger
+        config.headers.must_be_kind_of Misty::HTTP::Header
+        config.headers.get.must_equal({"Accept"=>"application/json; q=1.0"})
         config.interface.must_equal Misty::INTERFACE
+        config.log.must_be_kind_of Logger
         config.region_id.must_equal Misty::REGION_ID
         config.ssl_verify_mode.must_equal Misty::SSL_VERIFY_MODE
       end

--- a/test/unit/http/header_test.rb
+++ b/test/unit/http/header_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+require 'misty/http/client'
+
+describe Misty::HTTP::Header do
+  describe 'create' do
+    it 'successful with Hash parameter' do
+      header = Misty::HTTP::Header.new('key 1' => 'value 1', 'key 2' => 'value 2')
+
+      header.get.must_equal ({'key 1' => 'value 1', 'key 2' => 'value 2'})
+    end
+
+    it 'fails when parameter is not a Hash' do
+      proc do
+        header = Misty::HTTP::Header.new('A string')
+      end.must_raise Misty::HTTP::Header::TypeError
+    end
+
+    it 'fails when a key is not a String' do
+      proc do
+        header = Misty::HTTP::Header.new('key 1' => 'value 1', 2 => 'value 2')
+      end.must_raise Misty::HTTP::Header::ArgumentError
+    end
+
+    it 'fails when a value is not a String' do
+      proc do
+        header = Misty::HTTP::Header.new('key 1' => 'value 1', 'key 2' => 2)
+      end.must_raise Misty::HTTP::Header::ArgumentError
+    end
+  end
+
+  describe 'add' do
+    it 'merge headers' do
+      header = Misty::HTTP::Header.new('key 1' => 'value 1', 'key 2' => 'value 2')
+      header.add('key 3' => 'value 3', 'key 4' => 'value 4')
+
+      header.get.must_equal ({'key 1' => 'value 1', 'key 2' => 'value 2', 'key 3' => 'value 3', 'key 4' => 'value 4'})
+    end
+  end
+end

--- a/test/unit/http/method_builder_test.rb
+++ b/test/unit/http/method_builder_test.rb
@@ -39,13 +39,13 @@ describe Misty::HTTP::MethodBuilder do
   describe '#get_method' do
     class Service
       def self.api
-          {
-              '/' => { GET: [:list_api_versions] },
-              '/v2.0/' => { GET: [:show_api_v2_details] },
-              '/v2.0/extensions' => { GET: [:list_extensions] },
-              '/v2.0/extensions/{alias}' => { GET: [:show_extension_details] },
-              '/v2.0/networks/{network_id}' => { GET: [:show_network_details], PUT: [:update_network], DELETE: [:delete_network] }
-          }
+        {
+          '/' => { GET: [:list_api_versions] },
+          '/v2.0/' => { GET: [:show_api_v2_details] },
+          '/v2.0/extensions' => { GET: [:list_extensions] },
+          '/v2.0/extensions/{alias}' => { GET: [:show_extension_details] },
+          '/v2.0/networks/{network_id}' => { GET: [:show_network_details], PUT: [:update_network], DELETE: [:delete_network] }
+        }
       end
     end
 

--- a/test/unit/http/request_test.rb
+++ b/test/unit/http/request_test.rb
@@ -71,8 +71,8 @@ describe Misty::HTTP::Request do
 
     it '#http_head' do
       stub_request(:head, 'http://localhost/resource').
-      with(:headers => request_header).
-      to_return(:status => '200')
+        with(:headers => request_header).
+        to_return(:status => '200')
 
       response = service.http_head('/resource', {})
       response.must_be_kind_of Net::HTTPSuccess
@@ -81,8 +81,8 @@ describe Misty::HTTP::Request do
 
     it '#http_options' do
       stub_request(:options, 'http://localhost/resource').
-      with(:headers => request_header).
-      to_return(:status => '200')
+        with(:headers => request_header).
+        to_return(:status => '200')
 
       response = service.http_options('/resource', {})
       response.must_be_kind_of Net::HTTPSuccess

--- a/test/unit/microversion_test.rb
+++ b/test/unit/microversion_test.rb
@@ -37,6 +37,7 @@ describe Misty::Microversion do
     setup.interface = Misty::INTERFACE
     setup.region_id = Misty::REGION_ID
     setup.ssl_verify_mode = Misty::SSL_VERIFY_MODE
+    setup.headers = Misty::HTTP::Header.new('Accept' => 'application/json; q=1.0')
 
     stub_request(:get, 'http://localhost/').
       with(:headers => {'Accept'=>'application/json'}).

--- a/test/unit/service_helper.rb
+++ b/test/unit/service_helper.rb
@@ -4,7 +4,7 @@ def request_header
   {'Accept' => 'application/json; q=1.0'}
 end
 
-def service(content_type = :ruby)
+def service(content_type = :ruby, params = {})
   auth = Minitest::Mock.new
 
   def auth.get_url(*args)
@@ -21,10 +21,11 @@ def service(content_type = :ruby)
   setup.interface = Misty::INTERFACE
   setup.region_id = Misty::REGION_ID
   setup.ssl_verify_mode = Misty::SSL_VERIFY_MODE
+  setup.headers = Misty::HTTP::Header.new('Accept' => 'application/json; q=1.0')
 
   stub_request(:get, 'http://localhost/').
     with(:headers => request_header).
     to_return(:status => 200, :body => '', :headers => {})
 
-  Misty::Openstack::Neutron::V2_0.new(auth, setup, {})
+  Misty::Openstack::Neutron::V2_0.new(auth, setup, params)
 end


### PR DESCRIPTION
Adds option to inject customized headers for any request.
Also refactor global and service level headers.
Fixes ssl_verify_mode option.

Resolves https://github.com/flystack/misty/issues/81