### PR TITLE
Re-adding JSON encoded data with header

### DIFF
--- a/lib/misty/misty.rb
+++ b/lib/misty/misty.rb
@@ -48,6 +48,20 @@ module Misty
   # Default when uri.scheme is https
   SSL_VERIFY_MODE = true
 
+  def self.json_encode?(data)
+    return true if data.is_a?(Array) || data.is_a?(Hash)
+    if data.is_a?(String)
+      begin
+        JSON.parse(data)
+      rescue JSON::ParserError
+        return false
+      else
+        return true
+      end
+    end
+    return false
+  end
+
   def self.services
     services = Misty::Services.new
     SERVICES.each do |service|

--- a/test/unit/cloud/requests_test.rb
+++ b/test/unit/cloud/requests_test.rb
@@ -81,13 +81,49 @@ describe Misty::Cloud do
     end
 
     it 'sucessful whith elements in pathwhith elements in path' do
-        stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
-          to_return(:status => 200, :body => JSON.dump(auth_response_v3('orchestration', 'heat')), :headers => {'x-subject-token'=>'token_data'})
+      stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+        to_return(:status => 200, :body => JSON.dump(auth_response_v3('orchestration', 'heat')), :headers => {'x-subject-token'=>'token_data'})
 
-        stub_request(:post, 'http://localhost/stacks/id1/id2/snapshots').
-        to_return(:status => 201, :body => 'snapshots', :headers => {})
+      stub_request(:post, 'http://localhost/stacks/id1/id2/snapshots').
+      to_return(:status => 201, :body => 'snapshots', :headers => {})
 
-        cloud.orchestration.snapshot_a_stack('id1', 'id2', "{\"key\": \"value\"}").response.must_be_kind_of Net::HTTPCreated
+      cloud.orchestration.snapshot_a_stack('id1', 'id2', "{\"key\": \"value\"}").response.must_be_kind_of Net::HTTPCreated
+    end
+
+    it 'sucessful whith Array type data' do
+      stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+        to_return(:status => 200, :body => JSON.dump(auth_response_v3('network', 'neutron')), :headers => {'x-subject-token'=>'token_data'})
+
+      stub_request(:post, 'http://localhost/v2.0/networks').
+        with(:body => "[\"network\",{\"name\":\"network1\"}]").
+        with(:headers => {'Content-Type'=>'application/json'}).
+        to_return(:status => 201, :body => "", :headers => {})
+
+      cloud.networking.create_network(['network', {'name' => 'network1'}]).response.must_be_kind_of Net::HTTPCreated
+    end
+
+    it 'sucessful with Hash type data' do
+      stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+        to_return(:status => 200, :body => JSON.dump(auth_response_v3('network', 'neutron')), :headers => {'x-subject-token'=>'token_data'})
+
+      stub_request(:post, 'http://localhost/v2.0/networks').
+        with(:body => "{\"network\":{\"name\":\"network1\"}}").
+        with(:headers => {'Content-Type'=>'application/json'}).
+        to_return(:status => 201, :body => "", :headers => {})
+
+      cloud.networking.create_network({'network' => {'name' => 'network1'}}).response.must_be_kind_of Net::HTTPCreated
+    end
+
+    it 'sucessful with JSON String data' do
+      stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+        to_return(:status => 200, :body => JSON.dump(auth_response_v3('network', 'neutron')), :headers => {'x-subject-token'=>'token_data'})
+
+      stub_request(:post, 'http://localhost/v2.0/networks').
+        with(:body => "{\"network\":{\"name\":\"network1\"}}").
+        with(:headers => {'Content-Type'=>'application/json'}).
+        to_return(:status => 201, :body => "", :headers => {})
+
+      cloud.networking.create_network("{\"network\":{\"name\":\"network1\"}}").response.must_be_kind_of Net::HTTPCreated
     end
 
     it 'fails when not enough arguments' do
@@ -121,6 +157,42 @@ describe Misty::Cloud do
         to_return(:status => 200, :body => 'list of group/role for a domain', :headers => {})
 
       cloud.identity.assign_role_to_group_on_domain('domain_id', 'group_id', 'roles_id').response.must_be_kind_of Net::HTTPOK
+    end
+
+    it 'sucessful whith Array type data' do
+      stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+        to_return(:status => 200, :body => JSON.dump(auth_response_v3('network', 'neutron')), :headers => {'x-subject-token'=>'token_data'})
+
+      stub_request(:put, 'http://localhost/v2.0/networks/network_id').
+        with(:body => "[\"network\",{\"name\":\"network2\"}]").
+        with(:headers => {'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => "", :headers => {})
+
+      cloud.networking.update_network('network_id', ['network', {'name' => 'network2'}]).response.must_be_kind_of Net::HTTPOK
+    end
+
+    it 'sucessful with Hash type data' do
+      stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+        to_return(:status => 200, :body => JSON.dump(auth_response_v3('network', 'neutron')), :headers => {'x-subject-token'=>'token_data'})
+
+      stub_request(:put, 'http://localhost/v2.0/networks/network_id').
+        with(:body => "{\"network\":{\"name\":\"network2\"}}").
+        with(:headers => {'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => "", :headers => {})
+
+      cloud.networking.update_network('network_id', {'network' => {'name' => 'network2'}}).response.must_be_kind_of Net::HTTPOK
+    end
+
+    it 'sucessful with JSON String data' do
+      stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+        to_return(:status => 200, :body => JSON.dump(auth_response_v3('network', 'neutron')), :headers => {'x-subject-token'=>'token_data'})
+
+      stub_request(:put, 'http://localhost/v2.0/networks/network_id').
+        with(:body => "{\"network\":{\"name\":\"network2\"}}").
+        with(:headers => {'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => "", :headers => {})
+
+      cloud.networking.update_network('network_id', "{\"network\":{\"name\":\"network2\"}}").response.must_be_kind_of Net::HTTPOK
     end
   end
 end

--- a/test/unit/http/request_test.rb
+++ b/test/unit/http/request_test.rb
@@ -88,32 +88,41 @@ describe Misty::HTTP::Request do
       response.must_be_kind_of Net::HTTPSuccess
     end
 
-    it '#http_patch' do
-      stub_request(:patch, 'http://localhost/resource').
-        with(:headers => request_header).
-        to_return(:status => 202, :body => "{\"key\": \"value\"}")
+    describe '#http_patch' do
+      it 'successful with data of type String' do
+        stub_request(:patch, 'http://localhost/resource').
+          with(:body => "{\"data\":\"value\"}").
+          with(:headers => request_header).
+          to_return(:status => 202, :body => "{\"key\": \"value\"}")
 
-      response = service.http_patch('/resource', {},  'data' => 'value')
-      response.must_be_kind_of Net::HTTPAccepted
-      response.body.wont_be_nil
+        response = service.http_patch('/resource', {}, "{\"data\":\"value\"}")
+        response.must_be_kind_of Net::HTTPAccepted
+        response.body.wont_be_nil
+      end
     end
 
-    it '#http_post' do
-      stub_request(:post, 'http://localhost/resource').
-        with(:headers => request_header).
-        to_return(:status => 201)
+    describe '#http_post' do
+      it 'successful with data of type String' do
+        stub_request(:post, 'http://localhost/resource').
+          with(:body => "{\"data\":\"value\"}").
+          with(:headers => request_header).
+          to_return(:status => 201)
 
-      response = service.http_post('/resource', {},  'data' => 'value')
-      response.must_be_kind_of Net::HTTPCreated
+        response = service.http_post('/resource', {}, "{\"data\":\"value\"}")
+        response.must_be_kind_of Net::HTTPCreated
+      end
     end
 
-    it '#http_put' do
-      stub_request(:put, 'http://localhost/resource').
-      with(:headers => request_header).
-      to_return(:status => 200)
+    describe '#http_put' do
+      it 'successful with data of type String' do
+        stub_request(:put, 'http://localhost/resource').
+          with(:body => "{\"data\":\"value\"}").
+          with(:headers => request_header).
+          to_return(:status => 200)
 
-      response = service.http_put('/resource', {},  'data' => 'value')
-      response.must_be_kind_of Net::HTTPOK
+        response = service.http_put('/resource', {}, "{\"data\":\"value\"}")
+        response.must_be_kind_of Net::HTTPOK
+      end
     end
 
     it '#http_to_s' do

--- a/test/unit/misty_test.rb
+++ b/test/unit/misty_test.rb
@@ -142,6 +142,24 @@ describe Misty do
     end
   end
 
+  describe '#json_encode?' do
+    it 'true with a Array type' do
+      Misty.json_encode?([]).must_equal true
+    end
+
+    it 'true with a Hash type' do
+      Misty.json_encode?({}).must_equal true
+    end
+
+    it 'true with a JSON String type' do
+      Misty.json_encode?('{"JSON_Key": "JSON_Value"}').must_equal true
+    end
+
+    it 'false with a non JSON String type' do
+      Misty.json_encode?("Just a string").must_equal false
+    end
+  end
+
   describe '#to_json' do
     it 'returns a JSON string when using a Ruby hash' do
       Misty.to_json({'key' => 'val'}).must_be_kind_of String


### PR DESCRIPTION
For POST/PUT/PATCH requests, when data is an Array, Hash and JSON String type then the data is encoded to JSON (or just validated when a String) and the header `{'Content-Type'=>'application/json'}` is added.
