### PR TITLE
Build rules for importing OpenStack APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 .bundle/
 .byebug_history
+build/
 misty.log
 Gemfile.lock
 vendor

--- a/Rakefile
+++ b/Rakefile
@@ -2,25 +2,80 @@ require 'rake/testtask'
 
 task :default => [:test]
 
-desc "Run all tests"
+desc 'Run all tests'
 task :test => [:unit, :integration]
 
-desc "Run unit tests"
+desc 'Run unit tests'
 task :unit do
   Rake::TestTask.new do |t|
     t.name = 'unit'
-    t.libs << "test/unit"
+    t.libs << 'test/unit'
     t.test_files = FileList['test/unit/**/*_test.rb']
     t.verbose = true
   end
 end
 
-desc "Run integration tests"
+desc 'Run integration tests'
 task :integration do
   Rake::TestTask.new do |t|
     t.name = 'integration'
     t.libs << "test/integration"
-    t.test_files = FileList['test/integration/**/*_test.rb']
+     t.test_files = FileList['test/integration/**/*_test.rb']
     t.verbose = true
+  end
+end
+
+desc 'Build APIs'
+task :build => 'build:all'
+
+namespace :build do
+  task :all => [:setup, :run]
+
+  desc 'Clean Build'
+  task :clean do
+    require 'fileutils'
+    FileUtils.rm_r('build') if Dir.exist?('build')
+  end
+
+  desc 'Prepare Build APIs'
+  task :setup do
+    Dir.mkdir('build') unless Dir.exist?('build')
+    Dir.mkdir('build/APIs') unless Dir.exist?('build/APIs')
+    unless Dir.exist?('./build/openstack-APIs')
+    `git clone https://github.com/flystack/openstack-APIs build/openstack-APIs`
+    end
+  end
+
+  desc 'Process APIs'
+  task :run do
+    require 'pp'
+    require 'yaml'
+
+    Dir.glob("build/openstack-APIs/APIs/*/*.yaml") do |entry|
+      path = entry.gsub('.yaml', '').split('/')
+      name = path[-2]
+      version = path[-1].gsub(/\./,'_')
+      api = YAML.load_file(entry)
+      Dir.mkdir("build/APIs/#{name}") unless Dir.exist?("build/APIs/#{name}")
+      puts "Generating build/APIs/#{name}/#{name}_#{version}.rb"
+      File.open("build/APIs/#{name}/#{name}_#{version}.rb", 'w') do |f|
+        f << "module Misty::Openstack::#{name.capitalize}#{version.capitalize}\n"
+        f << "  def #{version}\n"
+        PP.pp(api, f)
+        f << "  end\n"
+        f << "end\n"
+      end
+    end
+  end
+
+  desc 'Compare APIs'
+  task :diff do
+    Dir.glob("build/APIs/*/*.rb") do |entry|
+      path = entry.split('/')
+      name = path[-2]
+      file = path[-1]
+     `diff lib/misty/openstack/#{name}/#{file} build/APIs/#{name}/#{file}`
+     puts "Not the same: #{name}/#{file}" if $?
+    end
   end
 end


### PR DESCRIPTION
Rakefile `:build` namespace importing https://github.com/flystack/openstack-APIs and generating module files.