### PR TITLE
Bugfixes

### DIFF
--- a/lib/misty/http/method_builder.rb
+++ b/lib/misty/http/method_builder.rb
@@ -16,7 +16,6 @@ module Misty
           header.add('Content-Type' => 'application/json')
           return Misty.to_json(args[0])
         elsif args.size == 1
-          # fallback for content that cannot be encoded to json
           return args[0]
         end
       end

--- a/lib/misty/http/method_builder.rb
+++ b/lib/misty/http/method_builder.rb
@@ -15,6 +15,9 @@ module Misty
         if args.size == 1 && Misty.json_encode?(args[0])
           header.add('Content-Type' => 'application/json')
           return Misty.to_json(args[0])
+        elsif args.size == 1
+          # fallback for content that cannot be encoded to json
+          return args[0]
         end
       end
 


### PR DESCRIPTION
* 99fcbbf  I use three misty clients at the same time so with the class variables ``@@requests_added and  @@requests_api`` the variables are overwriten by each other. To use mutex solved the problem
* 7c4ecc3 for bulk_delete we need to POST a list of objects in the body but process_data returns nothing because the args_left (in that case the object list) is not json encoded so I added a fallback