### PR TITLE
Small fixes

### DIFF
--- a/lib/misty/http/client.rb
+++ b/lib/misty/http/client.rb
@@ -23,23 +23,31 @@ module Misty
 
       attr_reader :headers, :microversion
 
+      @@request_api_add_mutex = Mutex.new
+      @@request_api_mutex     = Mutex.new
       @@requests_added = []
-      @@requests_api = []
+      @@requests_api   = []
 
       def self.api_add(*args)
-        @@requests_added = []
-        @@requests_added << args
+        # made write access thread safe 
+        @@request_api_add_mutex.synchronize do 
+          @@requests_added.push(*args).flatten!
+          @@requests_added.uniq!
+        end
         return nil
       end
 
       def self.init_requests
-        @@requests_api = []
-        api.each do |_path, verbs|
-          verbs.each do |_verb, requests|
-            @@requests_api << requests
+        # made write access thread safe 
+        @@request_api_mutex.synchronize do 
+          api.each do |_path, verbs|
+            verbs.each do |_verb, requests|
+              @@requests_api << requests
+            end
           end
+          @@requests_api.flatten!
+          @@requests_api.uniq!
         end
-        @@requests_api.flatten!
         return nil
       end
 

--- a/lib/misty/http/method_builder.rb
+++ b/lib/misty/http/method_builder.rb
@@ -15,6 +15,8 @@ module Misty
         if args.size == 1 && Misty.json_encode?(args[0])
           header.add('Content-Type' => 'application/json')
           return Misty.to_json(args[0])
+        elsif args.size == 1
+          return args[0]
         end
       end
 


### PR DESCRIPTION
* a79bbbd We use three misty clients at the same time so with the class variables ``@@requests_added``
 and  ``@@requests_api`` the variables are overwriten by each other. To prevent that behavior I removed the reseting of the class variables and secured the write access with a global mutex. The downside: the global request variable is growing and contains all requests that where ever loaded. I am not sure thats a good idea but it works ;-) Maybe there is a better way?
* edf9997 for bulk_delete we need to POST a list of objects in the body but process_data returns nothing because the args_left (in that case the object list) is not json encoded so I added a fallback