### PR TITLE
Add the OpenLab CI integration to Misty

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,5 @@
+- project:
+    check:
+      jobs:
+        - misty-unit-test
+        - misty-integration-test


### PR DESCRIPTION
This change add the OpenLab CI jobs entrypoint for Misty to be used to
trigger jobs of unit tests and integration tests.

For #116