### PR TITLE
Allow auth_url path

### DIFF
--- a/lib/misty/auth/token.rb
+++ b/lib/misty/auth/token.rb
@@ -43,7 +43,8 @@ module Misty
         Misty::HTTP::NetHTTP.http_request(
           creds[:uri], ssl_verify_mode: creds[:ssl_verify_mode], log: @log
         ) do |connection|
-          response = connection.post(path, creds[:data].to_json,
+          connect_path = creds[:uri].path + path
+          response = connection.post(connect_path, creds[:data].to_json,
             { 'Content-Type' => 'application/json', 'Accept' => 'application/json' })
           unless response.code =~ /200|201/
             raise AuthenticationError, "Response code=#{response.code}, Msg=#{response.msg}"

--- a/test/unit/auth/token_test.rb
+++ b/test/unit/auth/token_test.rb
@@ -5,7 +5,7 @@ describe Misty::Auth::Token do
   describe 'V3' do
     describe '#new' do
       it 'fails when missing credentials' do
-        stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+        stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
         to_return(:status => 200, :body => "{\"token\":{\"catalog\":[]}}", :headers => {'x-subject-token'=>'token_data'})
         proc do
           token = Misty::Auth::Token.build({})
@@ -16,31 +16,30 @@ describe Misty::Auth::Token do
         describe 'with a project scope' do
           it 'authenticates using a project id' do
             auth = {
-              :url             => 'http://localhost:5000',
+              :url             => 'http://localhost/identity',
               :user_id         => 'user_id',
               :password        => 'secret',
               :project_id      => 'project_id',
               :ssl_verify_mode => false
             }
 
-            stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+            stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
               with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"id\":\"user_id\",\"password\":\"secret\"}}},\"scope\":{\"project\":{\"id\":\"project_id\"}}}}").
               to_return(:status => 200, :body => JSON.dump(auth_response_v3('identity', 'keystone')), :headers => {'x-subject-token'=>'token_data_v3'})
-
             token = Misty::Auth::Token.build(auth)
             token.get.must_equal 'token_data_v3'
           end
 
           it 'authenticates using a project name and a project domain id' do
             auth = {
-              :url               => 'http://localhost:5000',
+              :url               => 'http://localhost/identity',
               :user_id           => 'user_id',
               :password          => 'secret',
               :project           => 'project',
               :project_domain_id => 'project_domain_id'
             }
 
-            stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+            stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
               with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"id\":\"user_id\",\"password\":\"secret\"}}},\"scope\":{\"project\":{\"name\":\"project\",\"domain\":{\"id\":\"project_domain_id\"}}}}}").
               to_return(:status => 200, :body => JSON.dump(auth_response_v3('identity', 'keystone')), :headers => {'x-subject-token'=>'token_data'})
             token = Misty::Auth::Token.build(auth)
@@ -49,7 +48,7 @@ describe Misty::Auth::Token do
 
           it 'authenticates using a project name and a project domain name' do
             auth = {
-              :url               => 'http://localhost:5000',
+              :url               => 'http://localhost/identity',
               :user              => 'user',
               :user_domain       => 'user_domain',
               :password          => 'secret',
@@ -57,7 +56,7 @@ describe Misty::Auth::Token do
               :project_domain    => 'project_domain'
             }
 
-            stub_request(:post, "http://localhost:5000/v3/auth/tokens").
+            stub_request(:post, "http://localhost/identity/v3/auth/tokens").
               with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"name\":\"user\",\"domain\":{\"name\":\"user_domain\"},\"password\":\"secret\"}}},\"scope\":{\"project\":{\"name\":\"project\",\"domain\":{\"name\":\"project_domain\"}}}}}").
               to_return(:status => 200, :body => JSON.dump(auth_response_v3('identity', 'keystone')), :headers => {'x-subject-token'=>'token_data'})
 
@@ -69,13 +68,13 @@ describe Misty::Auth::Token do
         describe 'with a domain scope' do
           it 'authenticates using a domain id' do
             auth = {
-              :url       => 'http://localhost:5000',
+              :url       => 'http://localhost/identity',
               :user_id   => 'user_id',
               :password  => 'secret',
               :domain_id => 'domain_id'
             }
 
-            stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+            stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
               with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"id\":\"user_id\",\"password\":\"secret\"}}},\"scope\":{\"domain\":{\"id\":\"domain_id\"}}}}").
               to_return(:status => 200, :body => JSON.dump(auth_response_v3('identity', 'keystone')), :headers => {'x-subject-token'=>'token_data'})
 
@@ -85,13 +84,13 @@ describe Misty::Auth::Token do
 
           it 'authenticates using a domain name' do
             auth = {
-              :url      => 'http://localhost:5000',
+              :url      => 'http://localhost/identity',
               :user_id  => 'user_id',
               :password => 'secret',
               :domain   => 'domain'
             }
 
-            stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+            stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
               with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"id\":\"user_id\",\"password\":\"secret\"}}},\"scope\":{\"domain\":{\"name\":\"domain\"}}}}").
               to_return(:status => 200, :body => JSON.dump(auth_response_v3('identity', 'keystone')), :headers => {'x-subject-token'=>'token_data'})
 
@@ -105,12 +104,12 @@ describe Misty::Auth::Token do
         describe 'with a project scope' do
           it 'authenticates using a project id' do
             auth = {
-              :url        => 'http://localhost:5000',
+              :url        => 'http://localhost/identity',
               :token      => 'token',
               :project_id => 'project_id'
             }
 
-            stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+            stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
               with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"token\"],\"token\":{\"id\":\"token\"}},\"scope\":{\"project\":{\"id\":\"project_id\"}}}}").
               to_return(:status => 200, :body => JSON.dump(auth_response_v3('identity', 'keystone')), :headers => {'x-subject-token'=>'token_data'})
 
@@ -120,13 +119,13 @@ describe Misty::Auth::Token do
 
           it 'authenticates using a project name and a project domain id' do
             auth = {
-              :url               => 'http://localhost:5000',
+              :url               => 'http://localhost/identity',
               :token             => 'token',
               :project           => 'project',
               :project_domain_id => 'domain_id'
             }
 
-            stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+            stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
               with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"token\"],\"token\":{\"id\":\"token\"}},\"scope\":{\"project\":{\"name\":\"project\",\"domain\":{\"id\":\"domain_id\"}}}}}").
               to_return(:status => 200, :body => JSON.dump(auth_response_v3('identity', 'keystone')), :headers => {'x-subject-token'=>'token_data'})
 
@@ -138,12 +137,12 @@ describe Misty::Auth::Token do
         describe 'with a domain scope' do
           it 'authenticates using a domain id' do
             auth = {
-              :url       => 'http://localhost:5000',
+              :url       => 'http://localhost/identity',
               :token     => 'token',
               :domain_id => 'domain_id'
             }
 
-            stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+            stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
               with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"token\"],\"token\":{\"id\":\"token\"}},\"scope\":{\"domain\":{\"id\":\"domain_id\"}}}}").
               to_return(:status => 200, :body => JSON.dump(auth_response_v3('identity', 'keystone')), :headers => {'x-subject-token'=>'token_data'})
 
@@ -153,12 +152,12 @@ describe Misty::Auth::Token do
 
           it 'authenticates using a domain name' do
             auth = {
-              :url    => 'http://localhost:5000',
+              :url    => 'http://localhost/identity',
               :token  => 'token',
               :domain => 'domain'
             }
 
-            stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+            stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
               with(:body => "{\"auth\":{\"identity\":{\"methods\":[\"token\"],\"token\":{\"id\":\"token\"}},\"scope\":{\"domain\":{\"name\":\"domain\"}}}}").
               to_return(:status => 200, :body => JSON.dump(auth_response_v3('identity', 'keystone')), :headers => {'x-subject-token'=>'token_data'})
 
@@ -172,7 +171,7 @@ describe Misty::Auth::Token do
     describe 'when authenticated' do
       let(:authv3_creds) do
         {
-          :url              => 'http://localhost:5000',
+          :url              => 'http://localhost/identity',
           :user             => 'admin',
           :password         => 'secret',
           :project          => 'admin',
@@ -182,7 +181,7 @@ describe Misty::Auth::Token do
 
       describe '#get' do
         it 'when token has not expired' do
-          stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+          stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
           to_return(:status => 200, :body => "{\"token\":{\"catalog\":[\"catalog_data\"]}}", :headers => {'x-subject-token'=>'token_data'})
 
           token = Misty::Auth::Token.build(authv3_creds)
@@ -192,7 +191,7 @@ describe Misty::Auth::Token do
         end
 
         it 'when token has expired' do
-          stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+          stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
           to_return(:status => 200, :body => "{\"token\":{\"catalog\":[\"catalog_data\"]}}", :headers => {'x-subject-token'=>'token_data'})
 
           token = Misty::Auth::Token.build(authv3_creds)
@@ -203,7 +202,7 @@ describe Misty::Auth::Token do
       end
 
       it '#catalog' do
-        stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+        stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
         to_return(:status => 200, :body => "{\"token\":{\"catalog\":[\"catalog_data\"]}}", :headers => {'x-subject-token'=>'token_data'})
 
         token = Misty::Auth::Token.build(authv3_creds)
@@ -211,7 +210,7 @@ describe Misty::Auth::Token do
       end
 
       it '#get_endpoint_url' do
-        stub_request(:post, 'http://localhost:5000/v3/auth/tokens').
+        stub_request(:post, 'http://localhost/identity/v3/auth/tokens').
         to_return(:status => 200, :body => JSON.dump(auth_response_v3("identity", "keystone")), :headers => {'x-subject-token'=>'token_data'})
 
         token = Misty::Auth::Token.build(authv3_creds)
@@ -223,7 +222,7 @@ describe Misty::Auth::Token do
   describe 'V2' do
     describe '#new' do
       it 'fails when missing credentials' do
-        stub_request(:post, 'http://localhost:5000/v2.0/tokens').
+        stub_request(:post, 'http://localhost/identity/v2.0/tokens').
           to_return(:status => 200, :body => "{\"access\":{\"token\":{\"id\":\"token_data\"}}}", :headers => {})
 
         proc do
@@ -234,13 +233,13 @@ describe Misty::Auth::Token do
       describe 'using the password method' do
         it 'authenticates using the tenant name' do
           auth = {
-            :url      => 'http://localhost:5000',
+            :url      => 'http://localhost/identity',
             :user     => 'user',
             :password => 'secret',
             :tenant   => 'tenant',
           }
 
-          stub_request(:post, 'http://localhost:5000/v2.0/tokens').
+          stub_request(:post, 'http://localhost/identity/v2.0/tokens').
             with(:body => "{\"auth\":{\"passwordCredentials\":{\"username\":\"user\",\"password\":\"secret\"},\"tenantName\":\"tenant\"}}").
             to_return(:status => 200, :body => JSON.dump(auth_response_v2('identity', 'keystone')), :headers => {})
 
@@ -250,13 +249,13 @@ describe Misty::Auth::Token do
 
         it 'authenticates using the tenant id' do
           auth = {
-            :url       => 'http://localhost:5000',
+            :url       => 'http://localhost/identity',
             :user      => 'user',
             :password  => 'secret',
             :tenant_id => 'tenant_id',
           }
 
-          stub_request(:post, 'http://localhost:5000/v2.0/tokens').
+          stub_request(:post, 'http://localhost/identity/v2.0/tokens').
             with(:body => "{\"auth\":{\"passwordCredentials\":{\"username\":\"user\",\"password\":\"secret\"},\"tenantId\":\"tenant_id\"}}").
             to_return(:status => 200, :body => JSON.dump(auth_response_v2('identity', 'keystone')), :headers => {})
 
@@ -268,12 +267,12 @@ describe Misty::Auth::Token do
       describe 'using the token method' do
         it 'authenticates using the tenant name' do
           auth = {
-            :url    => 'http://localhost:5000',
+            :url    => 'http://localhost/identity',
             :token  => 'token_id',
             :tenant => 'tenant',
           }
 
-          stub_request(:post, 'http://localhost:5000/v2.0/tokens').
+          stub_request(:post, 'http://localhost/identity/v2.0/tokens').
             with(:body => "{\"auth\":{\"token\":{\"id\":\"token_id\"},\"tenantName\":\"tenant\"}}").
             to_return(:status => 200, :body => JSON.dump(auth_response_v2('identity', 'keystone')), :headers => {})
 
@@ -283,12 +282,12 @@ describe Misty::Auth::Token do
 
         it 'authenticates using the tenant id' do
           auth = {
-            :url       => 'http://localhost:5000',
+            :url       => 'http://localhost/identity',
             :token     => 'token_id',
             :tenant_id => 'tenant_id',
           }
 
-          stub_request(:post, 'http://localhost:5000/v2.0/tokens').
+          stub_request(:post, 'http://localhost/identity/v2.0/tokens').
             with(:body => "{\"auth\":{\"token\":{\"id\":\"token_id\"},\"tenantId\":\"tenant_id\"}}").
             to_return(:status => 200, :body => JSON.dump(auth_response_v2('identity', 'keystone')), :headers => {})
 
@@ -300,7 +299,7 @@ describe Misty::Auth::Token do
     describe 'when authenticated' do
       let(:authv2_creds) do
         {
-          :url      => 'http://localhost:5000',
+          :url      => 'http://localhost/identity',
           :user     => 'admin',
           :password => 'secret',
           :tenant   => 'admin'
@@ -309,7 +308,7 @@ describe Misty::Auth::Token do
 
       describe '#get' do
         it 'when token has not expired' do
-          stub_request(:post, 'http://localhost:5000/v2.0/tokens').
+          stub_request(:post, 'http://localhost/identity/v2.0/tokens').
             to_return(:status => 200, :body => "{\"access\":{\"token\":{\"id\":\"token_not_expired\"},\"serviceCatalog\":[\"catalog_data\"]}}", :headers => {})
 
           token = Misty::Auth::Token.build(authv2_creds)
@@ -319,7 +318,7 @@ describe Misty::Auth::Token do
         end
 
         it 'when token has expired' do
-          stub_request(:post, 'http://localhost:5000/v2.0/tokens').
+          stub_request(:post, 'http://localhost/identity/v2.0/tokens').
             to_return(:status => 200, :body => "{\"access\":{\"token\":{\"id\":\"token_expired\"},\"serviceCatalog\":[\"catalog_data\"]}}", :headers => {})
 
           token = Misty::Auth::Token.build(authv2_creds)
@@ -330,7 +329,7 @@ describe Misty::Auth::Token do
       end
 
       it '#catalog' do
-        stub_request(:post, 'http://localhost:5000/v2.0/tokens').
+        stub_request(:post, 'http://localhost/identity/v2.0/tokens').
           to_return(:status => 200, :body => "{\"access\":{\"token\":{\"id\":\"token_data\"},\"serviceCatalog\":[\"catalog_data\"]}}", :headers => {})
 
         token = Misty::Auth::Token.build(authv2_creds)
@@ -338,7 +337,7 @@ describe Misty::Auth::Token do
       end
 
       it '#get_endpoint_url' do
-        stub_request(:post, 'http://localhost:5000/v2.0/tokens').
+        stub_request(:post, 'http://localhost/identity/v2.0/tokens').
           to_return(:status => 200, :body => JSON.dump(auth_response_v2('identity', 'keystone')), :headers => {'x-subject-token'=>'token_data'})
 
         token = Misty::Auth::Token.build(authv2_creds)

--- a/test/unit/cloud_test.rb
+++ b/test/unit/cloud_test.rb
@@ -119,7 +119,7 @@ describe Misty::Cloud do
         it 'uses Misty::Auth::Token::V3' do
           authv2 = Minitest::Mock.new
 
-            Misty::Auth::Token::V2.stub :new, authv2 do
+          Misty::Auth::Token::V2.stub :new, authv2 do
             cloud = Misty::Cloud.new(:auth => authv2_data)
             assert_mock authv2
           end


### PR DESCRIPTION
The path for the authentication URL is taken in account.

For example when using against DevStack: `:url => http://192.168.1.6/identity`